### PR TITLE
Fix umlaut, capitalization for payment_type==None

### DIFF
--- a/ff_housing/templates/latex/invoice.tex
+++ b/ff_housing/templates/latex/invoice.tex
@@ -165,7 +165,7 @@ keine Umsatzsteuer berechnet.\\\\
 %- if invoice.payment_type == 'SEPA-DD'
   Der Betrag wird in den nächsten Tagen automatisch abgebucht.
 %- elif invoice.payment_type == None
-  Achtung: Bei erteiltem Einziehungsauftrag den Betrag bitte nicht Ueberweisen, dieser wird in den nächsten Tagen von Eurem Konto abgebucht.\\
+  Achtung: Bei erteiltem Einziehungsauftrag den Betrag bitte nicht überweisen. Dieser wird in den nächsten Tagen von Eurem Konto abgebucht.\\
 %- else
   Zahlbar innerhalb von 14 Tagen nach Rechnungserhalt.\\
   Achtung: Bei Überweisung oder Überweisungsauftrag im Verwendungszweck bitte \textbf{Housing-k\VAR{invoice.contact.id}} angeben.


### PR DESCRIPTION
This PR changes "Ueberweisen" to "überweisen" for invoices with payment type `None`.