### PR TITLE
Make payment ref "Housing-k..." case-insensitive

### DIFF
--- a/ff_housing/controller/paymentimport.py
+++ b/ff_housing/controller/paymentimport.py
@@ -115,7 +115,7 @@ class PaymentsImporter():
                             return False
 
         def findUserID(self):
-            m = re.search(r"Housing-k(\d+)", self.payment_reference)
+            m = re.search(r"(?i)Housing-k(\d+)", self.payment_reference)
             if m:
                 self.found_weak = False
                 self.found['uid'] = model.User.byID(int(m.group(1)))


### PR DESCRIPTION
This commit updates the regexp used for constructing user IDs
from payment references in Erste Payment JSON imports to match
case-insensitively.

Example using the regexp from before this commit:

```python
>>> "This is OK:"
>>> re.search(r"Housing-k(\d+)", "Housing-k000")
<re.Match object; span=(0, 12), match='Housing-k000'>
>>> "This doesn't match:"
>>> re.search(r"Housing-k(\d+)", "HOUSING-k000")
>>>
```

Example using the regexp per this commit:
```python
>>> "This is still OK:"
>>> re.search(r"(?i)Housing-k(\d+)", "Housing-k000")
<re.Match object; span=(0, 12), match='Housing-k000'>
>>> "This matches now:"
>>> re.search(r"(?i)Housing-k(\d+)", "HOUSING-k000")
<re.Match object; span=(0, 12), match='HOUSING-k000'>
```